### PR TITLE
Volume and Source selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/launch.json
 .vscode/settings.json
 .vscode/extensions.json
+.pio/*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ BenQ Projector MQTT <-> RS232 controller based on the [Homie MQTT convention](ht
 
 This project is a [Homie for ESP8266 v2.0.0](https://github.com/marvinroger/homie-esp8266/releases/tag/v2.0.0) sketch implementing [Homie 2.0.1](https://github.com/marvinroger/homie/releases/tag/v2.0.1).
 
+Reference for commands [Command Control](https://business-display.benq.com/content/dam/bb/en/product/projector/corporate/lx770/quick-start-guide/lx770-rs232-control-guide-0-windows7-windows8-winxp.pdf)
 The goal of the project is to support a big array of commands and thus not need to rely on the IR remote control but it will grow organically as I find time to work on it.
 
 The project follows [Semantic Versioning](http://semver.org/). It's currently on development (ergo the v0.x.y) towards the first version and is thus unstable in nature. Once it reaches a maturity level that I feel comfortable, I will bump the version to v1.0.0 and continue from there. 

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define INCLUDE_MAIN_HPP_
 
 #define FW_NAME      "homie-benq-projector-rs232"
-#define FW_VERSION   "0.1.1"
+#define FW_VERSION   "0.2.1"
 
 #define SERIAL_BAUD  115200
 #define SERIAL_HEAD  "\r*"

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -29,6 +29,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 void sendCommand(const String& command, const String& value);
 
+bool toggleHandler(const String& value, const String& cmd_key, const String& opt_1, const String& opt_2, const String& node_property);
+
 bool powerHandler(const HomieRange& range, const String& value);
 
 #endif  // INCLUDE_MAIN_HPP_

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -31,6 +31,10 @@ void sendCommand(const String& command, const String& value);
 
 bool toggleHandler(const String& value, const String& cmd_key, const String& opt_1, const String& opt_2, const String& node_property);
 
+bool volumeHandler(const HomieRange& range, const String& value);
+
+bool sourceHandler(const HomieRange& range, const String& value);
+
 bool powerHandler(const HomieRange& range, const String& value);
 
 #endif  // INCLUDE_MAIN_HPP_

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define INCLUDE_MAIN_HPP_
 
 #define FW_NAME      "homie-benq-projector-rs232"
-#define FW_VERSION   "0.1.0"
+#define FW_VERSION   "0.1.1"
 
 #define SERIAL_BAUD  115200
 #define SERIAL_HEAD  "\r*"

--- a/include/main.hpp
+++ b/include/main.hpp
@@ -19,7 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define INCLUDE_MAIN_HPP_
 
 #define FW_NAME      "homie-benq-projector-rs232"
-#define FW_VERSION   "0.2.1"
+#define FW_VERSION   "0.3.1"
 
 #define SERIAL_BAUD  115200
 #define SERIAL_HEAD  "\r*"
@@ -36,5 +36,8 @@ bool volumeHandler(const HomieRange& range, const String& value);
 bool sourceHandler(const HomieRange& range, const String& value);
 
 bool powerHandler(const HomieRange& range, const String& value);
+
+bool muteHandler(const HomieRange& range, const String& value);
+
 
 #endif  // INCLUDE_MAIN_HPP_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,9 @@ bool powerHandler(const HomieRange& range, const String& value) {
     return toggleHandler(value, "pow", "on", "off", "power");
 }
 
+bool muteHandler(const HomieRange& range, const String& value) {
+    return toggleHandler(value, "mute", "on", "off", "mute");
+}
 void setup() {
     Homie.disableLogging();
     Serial.begin(SERIAL_BAUD);
@@ -67,6 +70,9 @@ void setup() {
     projectorNode.advertise("power").settable(powerHandler);
     projectorNode.advertise("source").settable(sourceHandler);
     projectorNode.advertise("volume").settable(volumeHandler);
+    projectorNode.advertise("mute").settable(muteHandler);
+    // projectorNode.advertise("volumelvl");
+
 }
 
 void loop() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ bool toggleHandler(const String& value, const String& cmd_key, const String& opt
 
 
 bool sourceHandler(const HomieRange& range, const String& value) {
-    return toggleHandler(value, "sour", "hdmi1", "hdmi2", "source");
+    return toggleHandler(value, "sour", "hdmi", "hdmi2", "source");
 }
 
 bool volumeHandler(const HomieRange& range, const String& value){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,15 +30,20 @@ void sendCommand(const String& command, const String& value) {
     Serial.print(SERIAL_TRAIL);
 }
 
-bool powerHandler(const HomieRange& range, const String& value) {
-    if (value != "on" && value != "off") {
+bool toggleHandler(const String& value, const String& cmd_key, const String& opt_1, const String& opt_2, const String& node_property)
+{
+    if (value != opt_1 && value != opt_2) {
         return false;
     }
 
-    sendCommand("pow", value);
-    projectorNode.setProperty("power").send(value);
+    sendCommand(cmd_key, value);
+    projectorNode.setProperty(node_property).send(value);
 
     return true;
+}
+
+bool powerHandler(const HomieRange& range, const String& value) {
+    return toggleHandler(value, "pow", "on", "off", "power");
 }
 
 void setup() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,16 @@ bool toggleHandler(const String& value, const String& cmd_key, const String& opt
     return true;
 }
 
+
+bool sourceHandler(const HomieRange& range, const String& value) {
+    return toggleHandler(value, "sour", "hdmi1", "hdmi2", "source");
+}
+
+bool volumeHandler(const HomieRange& range, const String& value){
+    // TODO: note that property volume can be also read with <CR>*vol=?#<CR> and thus publish the actual volume value instead of +/-
+    return toggleHandler(value, "vol", "+", "-", "volume");
+}
+
 bool powerHandler(const HomieRange& range, const String& value) {
     return toggleHandler(value, "pow", "on", "off", "power");
 }
@@ -55,6 +65,8 @@ void setup() {
     Homie.setup();
 
     projectorNode.advertise("power").settable(powerHandler);
+    projectorNode.advertise("source").settable(sourceHandler);
+    projectorNode.advertise("volume").settable(volumeHandler);
 }
 
 void loop() {


### PR DESCRIPTION
This PR includes the functionality to select between two sources ( `hdmi` and `hdmi2`).
The way it was implemented was by using the same functionality developed for the powering.
Missing:
- Validation that the projector is powered before sending other controlling commands 
- Volume status can be read and publish the numerical value instead of + or -
- Source selection can be expanded to further sources

